### PR TITLE
Travis: More stable solution for removing Xdebug when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   # Set up temporary paths.
   - export PHPCS_DIR=/tmp/phpcs
   - export WPCS_DIR=/tmp/wpcs


### PR DESCRIPTION
Builds onto https://github.com/jrfnl/wp-known-plugin-dependencies/pull/5/commits/02a5fde33d1230a3c854455e77cd5485ea510c0b

As per https://twitter.com/kelunik/status/954242454676475904

When newer images of PHP versions become available, Xdebug isn't always installed.
Using this little titbit, the builds won't break because of it.